### PR TITLE
Refactored Branch

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,51 +16,108 @@ ollama pull mistral  # or llama3, etc.
 python main.py
 """
 
-from typing import TypedDict, List
-from langchain_core.messages import HumanMessage, SystemMessage
+# main.py
+# main.py
+# LangGraph: language -> (pronunciation & grammar) -> final
+# Backend: Ollama (mistral). Make sure `ollama serve` is running and you've done `ollama pull mistral`.
+
+from typing import TypedDict, Optional
 from langchain_ollama import ChatOllama
 from langgraph.graph import StateGraph, END
 
-# State schema
+# ---------- Shared state ----------
 class GraphState(TypedDict):
-    messages: List
+    input: str                     # user sentence (read-only once set)
+    language: Optional[str]        # set by language_node
+    pronunciation: Optional[str]   # set by pronunciation_node
+    analysis: Optional[str]        # set by grammar_node
+    output: Optional[str]          # set by final_node
 
-# LLM setup (Ollama)
-llm = ChatOllama(model="mistral")
+llm = ChatOllama(model="mistral", temperature=0)
 
-# MCP node
-def run_chat(state: GraphState) -> GraphState:
-    result = llm.invoke(state["messages"])
-    return {"messages": state["messages"] + [result]}
+# ---------- Parent: detect language ----------
+def language_node(state: GraphState) -> dict:
+    prompt = (
+        "Detect the language of this sentence. Reply with the language name only "
+        "(e.g., French, English, Korean).\n\n"
+        f"Sentence: {state['input']}"
+    )
+    res = llm.invoke(prompt)
+    return {"language": res.content.strip()}
 
-# Build graph
+# ---------- Child 1: pronunciation ----------
+def pronunciation_node(state: GraphState) -> dict:
+    prompt = (
+        "You are a pronunciation coach. For the sentence, provide:\n"
+        "1) An approximate IPA or phonetic guide\n"
+        "2) A syllable breakdown\n"
+        "3) Stress pattern (if relevant)\n"
+        "4) One or two mouth/tongue tips\n\n"
+        f"Language: {state.get('language','(unknown)')}\n"
+        f"Sentence: {state['input']}"
+    )
+    res = llm.invoke(prompt)
+    return {"pronunciation": res.content.strip()}
+
+# ---------- Child 2: grammar & context ----------
+def grammar_node(state: GraphState) -> dict:
+    prompt = (
+        "You are a multilingual tutor. For the sentence, provide:\n"
+        "1) An English translation (or say it's already English)\n"
+        "2) A brief word-by-word gloss (parts of speech / particles)\n"
+        "3) Key grammar points (tense, agreement, idioms, register)\n"
+        "4) One short usage/nuance tip\n\n"
+        f"Language: {state.get('language','(unknown)')}\n"
+        f"Sentence: {state['input']}"
+    )
+    res = llm.invoke(prompt)
+    return {"analysis": res.content.strip()}
+
+# ---------- Final: join & compose ----------
+def final_node(state: GraphState) -> dict:
+    # Only emit once both branches have produced results
+    if not state.get("pronunciation") or not state.get("analysis"):
+        return {}  # no-op until both are present
+
+    merged = (
+        f"## Language: {state.get('language','Unknown')}\n\n"
+        f"### Pronunciation\n{state['pronunciation']}\n\n"
+        f"### Context & Grammar\n{state['analysis']}"
+    )
+    return {"output": merged}
+
+# ---------- Build graph: language -> (pronunciation & grammar) -> final ----------
 builder = StateGraph(GraphState)
-builder.add_node("chat", run_chat)
-builder.set_entry_point("chat")
-builder.add_edge("chat", END)
-graph = builder.compile()
+builder.add_node("language", language_node)
+builder.add_node("pronunciation", pronunciation_node)
+builder.add_node("grammar", grammar_node)
+builder.add_node("final", final_node)
 
-# Ask user for input
-user_input = input("Enter a sentence (any language): ")
+builder.set_entry_point("language")
+# fan-out to children
+builder.add_edge("language", "pronunciation")
+builder.add_edge("language", "grammar")
+# join at final
+builder.add_edge("pronunciation", "final")
+builder.add_edge("grammar", "final")
+builder.add_edge("final", END)
 
-# Run the graph
-initial_state = {
-    "messages": [
-        SystemMessage(content="""
-You are a multilingual language-learning assistant. Your job is to:
-1. Translate foreign-language sentences into English.
-2. Break down each word and grammatical structure clearly.
-3. Explain the overall sentence meaning and nuance.
-4. If there are any typos in the inputted sentence then highlight and correct it, if there are none say nothing.
-5. Show pronounciations beside each part of the sentence that was broken apart.
-6. If the sentence is an idiomatic sentence then identify that and describe what it really means.
+app = builder.compile()
 
-Be concise but educational. Output should be clear and structured. If the sentence is already in 
-English point that out to the user and do nothing more.
-"""),
-        HumanMessage(content=user_input)
-    ]
-}
-output = graph.invoke(initial_state)
+if __name__ == "__main__":
+    while True:
+        text = input("\nEnter a sentence (or 'q' to quit): ").strip()
+        if not text or text.lower() in {"q", "quit", "exit"}:
+            break
 
-print("\n MCP Output:\n", output["messages"][-1].content)
+        # Set read-only inputs once; children never write to these keys
+        init: GraphState = {
+            "input": text,
+            "language": None,
+            "pronunciation": None,
+            "analysis": None,
+            "output": None,
+        }
+
+        out = app.invoke(init)
+        print("\n" + (out.get("output") or "No output produced."))


### PR DESCRIPTION

This pull request refactors `main.py` to build a modular language analysis pipeline using LangGraph and Ollama (Mistral), replacing the previous monolithic chat-based approach. The new design separates language detection, pronunciation coaching, grammar/context analysis, and final output composition into distinct nodes, improving clarity, maintainability, and extensibility.

**Pipeline redesign and modularization:**

* Replaces the previous chat-based workflow with a LangGraph pipeline, where the input sentence is processed through sequential nodes: language detection, pronunciation analysis, grammar/context analysis, and final output composition. (`main.py`, [main.pyL19-R123](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L19-R123))
* Defines dedicated node functions: `language_node`, `pronunciation_node`, `grammar_node`, and `final_node`, each responsible for a specific aspect of the analysis. (`main.py`, [main.pyL19-R123](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L19-R123))

**State management improvements:**

* Refactors the shared state to use a `GraphState` TypedDict with explicit keys for `input`, `language`, `pronunciation`, `analysis`, and `output`, improving type safety and clarity. (`main.py`, [main.pyL19-R123](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L19-R123))

**User experience and CLI changes:**

* Updates the CLI loop to prompt the user for input, run the graph pipeline, and print the structured output, with support for quitting via 'q', 'quit', or 'exit'. (`main.py`, [main.pyL19-R123](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L19-R123))

**Backend and prompt changes